### PR TITLE
The mnist program with new fictive API

### DIFF
--- a/recognize_digits/example.py
+++ b/recognize_digits/example.py
@@ -1,0 +1,68 @@
+"""
+A very basic example for how to use current Raw SWIG API to train mnist network.
+
+Current implementation uses Raw SWIG, which means the API call is directly \
+passed to C++ side of Paddle.
+
+The user api could be simpler and carefully designed.
+"""
+
+import paddle.v2 as paddle
+
+from mnist_util import read_from_mnist
+
+
+def main():
+    paddle.raw.initPaddle("-use_gpu=false",
+                          "-trainer_count=4")  # use 4 cpu cores
+
+    optimizer = paddle.optimizer.Optimizer(
+        learning_method=paddle.optimizer.AdamOptimizer(),
+        learning_rate=1e-4,
+        model_average=paddle.optimizer.ModelAverage(average_window=0.5),
+        regularization=paddle.optimizer.L2Regularization(rate=0.5),
+        batch_size=128)  # 原来settings包含了batch_size
+
+    # define network
+    imgs = paddle.layers.data_layer(name='pixel', size=784)
+    hidden1 = paddle.layers.fc_layer(input=imgs, size=200)
+    hidden2 = paddle.layers.fc_layer(input=hidden1, size=200)
+    inference = paddle.layers.fc_layer(
+        input=hidden2, size=10, act=paddle.config.SoftmaxActivation())
+    cost = paddle.layers.classification_cost(
+        input=inference, label=paddle.layers.data_layer(
+            name='label', size=10))
+
+    model = paddle.model.Model(layers=[cost], optimizer=optimizer)
+
+    model.rand_parameter()
+
+    # 希望把train_data和test_data写在一块，因为两者的处理逻辑很相似
+    # 去掉原来api设计中的model变量，这部分和model不相关
+    train_data, test_data = paddle.data.create_data_pool(
+        file_reader=read_from_mnist,
+        file_list=['./data/raw_data/train', './data/raw_data/test'],
+        shuffle=True)
+
+    # Training process.
+    model.start()
+
+    # 去掉多余的start和finish函数，也去掉原来的make_evaluator
+    # 能否把返回值直接作为evaluator输出呢？
+    for pass_id in xrange(2):
+        for batch_id, data_batch in enumerate(train_data):
+            batch_evaluator = model.train(data_batch)
+            print "Pass=%d, batch=%d" % (pass_id, batch_id), batch_evaluator
+
+        for _, data_batch in enumerate(test_data):
+            test_evaluator = model.test(data_batch)
+        print "TEST Pass=%d" % pass_id, test_evaluator
+
+        # 将训练和测试的cost画在一张图上
+        plot_cost(batch_evaluator.cost, test_evaluator.cost, pass_id)
+
+    model.finish()
+
+
+if __name__ == '__main__':
+    main()

--- a/recognize_digits/example.py
+++ b/recognize_digits/example.py
@@ -7,61 +7,41 @@ passed to C++ side of Paddle.
 The user api could be simpler and carefully designed.
 """
 
-import paddle.v2 as paddle
+import paddle
 
-from mnist_util import read_from_mnist
+from mnist_util import read_mnist_data
 
 
 def main():
-    paddle.raw.initPaddle("-use_gpu=false",
-                          "-trainer_count=4")  # use 4 cpu cores
+    paddle.init("-use_gpu=false", "-trainer_count=4")  # use 4 cpu cores
 
-    optimizer = paddle.optimizer.Optimizer(
-        learning_method=paddle.optimizer.AdamOptimizer(),
+    optimizer = paddle.optimizer.Adam(
         learning_rate=1e-4,
-        model_average=paddle.optimizer.ModelAverage(average_window=0.5),
-        regularization=paddle.optimizer.L2Regularization(rate=0.5),
-        batch_size=128)  # 原来settings包含了batch_size
+        model_average=paddle.modelAverage(average_window=0.5),
+        regularization=paddle.regularization.L2(rate=0.5),
+        batch_size=128)
 
     # define network
-    imgs = paddle.layers.data_layer(name='pixel', size=784)
-    hidden1 = paddle.layers.fc_layer(input=imgs, size=200)
-    hidden2 = paddle.layers.fc_layer(input=hidden1, size=200)
-    inference = paddle.layers.fc_layer(
-        input=hidden2, size=10, act=paddle.config.SoftmaxActivation())
-    cost = paddle.layers.classification_cost(
-        input=inference, label=paddle.layers.data_layer(
+    imgs = paddle.layer.data(name='pixel', size=784)
+    hidden1 = paddle.layer.fc(input=imgs, size=200)
+    hidden2 = paddle.layer.fc(input=hidden1, size=200)
+    inference = paddle.layer.fc(input=hidden2,
+                                size=10,
+                                act=paddle.activation.Softmax())
+    cost = paddle.cost.classification(
+        input=inference, label=paddle.layer.data(
             name='label', size=10))
 
-    model = paddle.model.Model(layers=[cost], optimizer=optimizer)
+    model = paddle.model.create(network=inference)
 
     model.rand_parameter()
 
-    # 希望把train_data和test_data写在一块，因为两者的处理逻辑很相似
-    # 去掉原来api设计中的model变量，这部分和model不相关
     train_data, test_data = paddle.data.create_data_pool(
         file_reader=read_from_mnist,
         file_list=['./data/raw_data/train', './data/raw_data/test'],
         shuffle=True)
 
-    # Training process.
-    model.start()
-
-    # 去掉多余的start和finish函数，也去掉原来的make_evaluator
-    # 能否把返回值直接作为evaluator输出呢？
-    for pass_id in xrange(2):
-        for batch_id, data_batch in enumerate(train_data):
-            batch_evaluator = model.train(data_batch)
-            print "Pass=%d, batch=%d" % (pass_id, batch_id), batch_evaluator
-
-        for _, data_batch in enumerate(test_data):
-            test_evaluator = model.test(data_batch)
-        print "TEST Pass=%d" % pass_id, test_evaluator
-
-        # 将训练和测试的cost画在一张图上
-        plot_cost(batch_evaluator.cost, test_evaluator.cost, pass_id)
-
-    model.finish()
+    optimizer.train(model=model, cost=cost, data=[train_data, test_data])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
在 @reyoung 之前设计的一份[api_trainer.py](https://github.com/reyoung/Paddle/blob/9360a1fc15dd6ddbf220416be2161381b30feed9/demo/mnist/api_train.py)上修改了几个部分：
1. batch_size放到了optimizer地方，原来settings部分两者是放在一起的。
2. train_data和test_data用一个函数来获得，因为两者处理逻辑很类似。
3. 去掉多余的start和finish函数，也去掉原来的make_evaluator，希望把model.train的返回值直接作为evaluator输出。
4. 增加plot_cost函数，可以将train_cost和test_cost画在一张图上。