### PR TITLE
change url in pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@
         files: \.md$
     -   id: trailing-whitespace
         files: \.md$
--   repo: git://github.com/Lucas-C/pre-commit-hooks
+-   repo: https://github.com/Lucas-C/pre-commit-hooks
     sha: v1.0.1
     hooks:
     -   id: forbid-crlf


### PR DESCRIPTION
由于公司网络限制，需要将url中的git:// 替换为https://。