### PR TITLE
Remove convert ipynb in hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,9 +32,4 @@
         entry: python pre-commit-hooks/convert_markdown_into_html.py
         language: system
         files: .+README(\.en)?\.md$
-    -   id: convert-markdown-into-ipynb
-        name: convert-markdown-into-ipynb
-        description: Convert README.md into README.ipynb and README.en.md into README.en.ipynb
-        entry: ./pre-commit-hooks/convert_markdown_into_ipynb.sh
-        language: system
-        files: .+README(\.en)?\.md$
+


### PR DESCRIPTION
* Because we do not explicitly add ipynb files in book. They are
  generated by script.