### PR TITLE
Add --allow-root for running jupyter 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ pandoc.template
 py_env*
 *.ipynb
 build
+Dockerfile

--- a/.tools/build_docker.sh
+++ b/.tools/build_docker.sh
@@ -37,7 +37,7 @@ RUN ${update_mirror_cmd}
     pip install -U matplotlib jupyter numpy requests scipy
 
 EXPOSE 8888
-CMD ["sh", "-c", "jupyter notebook --ip=0.0.0.0 --no-browser --NotebookApp.token='' --NotebookApp.disable_check_xsrf=True /book/"]
+CMD ["sh", "-c", "jupyter notebook --ip=0.0.0.0 --no-browser --allow-root --NotebookApp.token='' --NotebookApp.disable_check_xsrf=True /book/"]
 EOF
 
 docker build --no-cache  -t paddlepaddle/book:${paddle_tag}  -t paddlepaddle/book:${book_tag} .


### PR DESCRIPTION
Fix running jupyter failed:
```bash
[I 15:20:08.242 NotebookApp] Writing notebook server cookie secret to /root/.local/share/jupyter/runtime/notebook_cookie_secret
[W 15:20:08.257 NotebookApp] All authentication is disabled.  Anyone who can connect to this server will be able to run code.
[C 15:20:08.265 NotebookApp] Running as root is not recommended. Use --allow-root to bypass.
```