### PR TITLE
add profiling scripts

### DIFF
--- a/.tools/build_docker.sh
+++ b/.tools/build_docker.sh
@@ -32,9 +32,10 @@ RUN ${update_mirror_cmd}
     apt-get update && \
     apt-get install -y locales && \
     apt-get -y install gcc && \
+    apt-get -y install graphviz && \
     apt-get -y clean && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \
-    pip install -U matplotlib jupyter numpy requests scipy
+    pip install -U matplotlib jupyter numpy requests scipy gprof2dot
 
 EXPOSE 8888
 CMD ["sh", "-c", "jupyter notebook --ip=0.0.0.0 --no-browser --allow-root --NotebookApp.token='' --NotebookApp.disable_check_xsrf=True /book/"]

--- a/.tools/profile/get_stats.py
+++ b/.tools/profile/get_stats.py
@@ -1,0 +1,12 @@
+#!/usr/local/bin/python
+
+import pstats
+import sys
+
+file_readable = sys.argv[1] + ".readable"
+stream = open(file_readable, "w")
+
+p = pstats.Stats(sys.argv[1], stream=stream)
+p.strip_dirs().sort_stats("time").print_stats(20)
+p.strip_dirs().sort_stats("cumtime").print_stats(20)
+stream.close()

--- a/.tools/profile/profile.sh
+++ b/.tools/profile/profile.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+book_dir=/book
+work_dir=/book/.tools/profile
+pushd $book_dir
+array=()
+while IFS=  read -r -d $'\0'; do
+    array+=("$REPLY")
+done < <(find ${book_dir} -name train.py -print0)
+
+for file in "${array[@]}"; do
+    echo $file
+    dir=$(dirname "${file}")
+    result=${file%.*}'.prof'
+    result_png=${result}'.png'
+    pushd $dir
+    python -m cProfile -o $result $file
+    popd
+    ${work_dir}/get_stats.py $result
+    gprof2dot -f pstats $result | dot -Tpng -o $result_png
+done
+popd


### PR DESCRIPTION
#279 
Python provides [cProfile](https://docs.python.org/2/library/profile.html#module-cProfile) module to help us profiling python codes.  A common usage can be:
`python -m cProfile -o train.prof train.py`

Since train.prof is a binary file, we have to transfer it into readable text or graph. The [Pstats](https://docs.python.org/2/library/profile.html#pstats.Stats) module’s Stats class has a variety of methods for manipulating and printing the data saved into a profile results file.  Following is the usage:
```
import pstats
p = pstats.Stats('train.prof)
p.strip_dirs().sort_stats("time").print_stats(20)
p.strip_dirs().sort_stats("cumtime").print_stats(20)
```
And [gprof2dot](https://github.com/jrfonseca/gprof2dot) is a Python script to convert the output from profilers into a dot graph. Following is the usage:
```
gprof2dot -f pstats train.prof | dot -Tpng -o train.prof.png
```