### PR TITLE
Make save model examples no longer compress model.

### DIFF
--- a/02.recognize_digits/README.cn.md
+++ b/02.recognize_digits/README.cn.md
@@ -132,7 +132,6 @@ PaddlePaddle在API中提供了自动加载[MNIST](http://yann.lecun.com/exdb/mni
 首先，加载PaddlePaddle的V2 api包。
 
 ```python
-import gzip
 import paddle.v2 as paddle
 ```
 其次，定义三个不同的分类器：
@@ -256,7 +255,7 @@ def event_handler_plot(event):
         step += 1
     if isinstance(event, paddle.event.EndPass):
         # save parameters
-        with gzip.open('params_pass_%d.tar.gz' % event.pass_id, 'w') as f:
+        with open('params_pass_%d.tar' % event.pass_id, 'w') as f:
             parameters.to_tar(f)
 
         result = trainer.test(reader=paddle.batch(
@@ -275,7 +274,7 @@ def event_handler(event):
                 event.pass_id, event.batch_id, event.cost, event.metrics)
     if isinstance(event, paddle.event.EndPass):
         # save parameters
-        with gzip.open('params_pass_%d.tar.gz' % event.pass_id, 'w') as f:
+        with open('params_pass_%d.tar' % event.pass_id, 'w') as f:
             parameters.to_tar(f)
 
         result = trainer.test(reader=paddle.batch(

--- a/02.recognize_digits/README.md
+++ b/02.recognize_digits/README.md
@@ -131,7 +131,6 @@ PaddlePaddle provides a Python module, `paddle.dataset.mnist`, which downloads a
 A PaddlePaddle program starts from importing the API package:
 
 ```python
-import gzip
 import paddle.v2 as paddle
 ```
 
@@ -251,7 +250,7 @@ def event_handler_plot(event):
         step += 1
     if isinstance(event, paddle.event.EndPass):
         # save parameters
-        with gzip.open('params_pass_%d.tar.gz' % event.pass_id, 'w') as f:
+        with open('params_pass_%d.tar' % event.pass_id, 'w') as f:
             parameters.to_tar(f)
 
         result = trainer.test(reader=paddle.batch(
@@ -271,7 +270,7 @@ def event_handler(event):
                 event.pass_id, event.batch_id, event.cost, event.metrics)
     if isinstance(event, paddle.event.EndPass):
         # save parameters
-        with gzip.open('params_pass_%d.tar.gz' % event.pass_id, 'w') as f:
+        with open('params_pass_%d.tar' % event.pass_id, 'w') as f:
             parameters.to_tar(f)
 
         result = trainer.test(reader=paddle.batch(

--- a/02.recognize_digits/index.cn.html
+++ b/02.recognize_digits/index.cn.html
@@ -174,7 +174,6 @@ PaddlePaddle在API中提供了自动加载[MNIST](http://yann.lecun.com/exdb/mni
 首先，加载PaddlePaddle的V2 api包。
 
 ```python
-import gzip
 import paddle.v2 as paddle
 ```
 其次，定义三个不同的分类器：
@@ -298,7 +297,7 @@ def event_handler_plot(event):
         step += 1
     if isinstance(event, paddle.event.EndPass):
         # save parameters
-        with gzip.open('params_pass_%d.tar.gz' % event.pass_id, 'w') as f:
+        with open('params_pass_%d.tar' % event.pass_id, 'w') as f:
             parameters.to_tar(f)
 
         result = trainer.test(reader=paddle.batch(
@@ -317,7 +316,7 @@ def event_handler(event):
                 event.pass_id, event.batch_id, event.cost, event.metrics)
     if isinstance(event, paddle.event.EndPass):
         # save parameters
-        with gzip.open('params_pass_%d.tar.gz' % event.pass_id, 'w') as f:
+        with open('params_pass_%d.tar' % event.pass_id, 'w') as f:
             parameters.to_tar(f)
 
         result = trainer.test(reader=paddle.batch(

--- a/02.recognize_digits/index.html
+++ b/02.recognize_digits/index.html
@@ -173,7 +173,6 @@ PaddlePaddle provides a Python module, `paddle.dataset.mnist`, which downloads a
 A PaddlePaddle program starts from importing the API package:
 
 ```python
-import gzip
 import paddle.v2 as paddle
 ```
 
@@ -293,7 +292,7 @@ def event_handler_plot(event):
         step += 1
     if isinstance(event, paddle.event.EndPass):
         # save parameters
-        with gzip.open('params_pass_%d.tar.gz' % event.pass_id, 'w') as f:
+        with open('params_pass_%d.tar' % event.pass_id, 'w') as f:
             parameters.to_tar(f)
 
         result = trainer.test(reader=paddle.batch(
@@ -313,7 +312,7 @@ def event_handler(event):
                 event.pass_id, event.batch_id, event.cost, event.metrics)
     if isinstance(event, paddle.event.EndPass):
         # save parameters
-        with gzip.open('params_pass_%d.tar.gz' % event.pass_id, 'w') as f:
+        with open('params_pass_%d.tar' % event.pass_id, 'w') as f:
             parameters.to_tar(f)
 
         result = trainer.test(reader=paddle.batch(

--- a/02.recognize_digits/train.py
+++ b/02.recognize_digits/train.py
@@ -1,4 +1,3 @@
-import gzip
 import os
 from PIL import Image
 import numpy as np
@@ -85,7 +84,7 @@ def main():
                     event.pass_id, event.batch_id, event.cost, event.metrics)
         if isinstance(event, paddle.event.EndPass):
             # save parameters
-            with gzip.open('params_pass_%d.tar.gz' % event.pass_id, 'w') as f:
+            with open('params_pass_%d.tar' % event.pass_id, 'w') as f:
                 parameters.to_tar(f)
 
             result = trainer.test(reader=paddle.batch(

--- a/03.image_classification/README.cn.md
+++ b/03.image_classification/README.cn.md
@@ -156,7 +156,6 @@ Paddle API提供了自动加载cifar数据集模块 `paddle.dataset.cifar`。
 
 ```python
 import sys
-import gzip
 import paddle.v2 as paddle
 from vgg import vgg_bn_drop
 from resnet import resnet_cifar10
@@ -431,7 +430,7 @@ def event_handler(event):
             sys.stdout.flush()
     if isinstance(event, paddle.event.EndPass):
         # save parameters
-        with gzip.open('params_pass_%d.tar.gz' % event.pass_id, 'w') as f:
+        with open('params_pass_%d.tar' % event.pass_id, 'w') as f:
             parameters.to_tar(f)
 
         result = trainer.test(
@@ -498,7 +497,7 @@ test_data = []
 cur_dir = os.path.dirname(os.path.realpath(__file__))
 test_data.append((load_image(cur_dir + '/image/dog.png'),))
 
-# with gzip.open('params_pass_50.tar.gz', 'r') as f:
+# with open('params_pass_50.tar', 'r') as f:
 #    parameters = paddle.parameters.Parameters.from_tar(f)
 
 probs = paddle.infer(

--- a/03.image_classification/README.md
+++ b/03.image_classification/README.md
@@ -169,7 +169,6 @@ We must import and initialize PaddlePaddle (enable/disable GPU, set the number o
 
 ```python
 import sys
-import gzip
 import paddle.v2 as paddle
 from vgg import vgg_bn_drop
 from resnet import resnet_cifar10
@@ -438,7 +437,7 @@ def event_handler(event):
             sys.stdout.flush()
     if isinstance(event, paddle.event.EndPass):
         # save parameters
-        with gzip.open('params_pass_%d.tar.gz' % event.pass_id, 'w') as f:
+        with open('params_pass_%d.tar' % event.pass_id, 'w') as f:
             parameters.to_tar(f)
 
         result = trainer.test(
@@ -508,7 +507,7 @@ cur_dir = os.path.dirname(os.path.realpath(__file__))
 test_data.append((load_image(cur_dir + '/image/dog.png'),))
 
 # users can remove the comments and change the model name
-# with gzip.open('params_pass_50.tar.gz', 'r') as f:
+# with open('params_pass_50.tar', 'r') as f:
 #    parameters = paddle.parameters.Parameters.from_tar(f)
 
 probs = paddle.infer(

--- a/03.image_classification/index.cn.html
+++ b/03.image_classification/index.cn.html
@@ -198,7 +198,6 @@ Paddle API提供了自动加载cifar数据集模块 `paddle.dataset.cifar`。
 
 ```python
 import sys
-import gzip
 import paddle.v2 as paddle
 from vgg import vgg_bn_drop
 from resnet import resnet_cifar10
@@ -473,7 +472,7 @@ def event_handler(event):
             sys.stdout.flush()
     if isinstance(event, paddle.event.EndPass):
         # save parameters
-        with gzip.open('params_pass_%d.tar.gz' % event.pass_id, 'w') as f:
+        with open('params_pass_%d.tar' % event.pass_id, 'w') as f:
             parameters.to_tar(f)
 
         result = trainer.test(
@@ -540,7 +539,7 @@ test_data = []
 cur_dir = os.path.dirname(os.path.realpath(__file__))
 test_data.append((load_image(cur_dir + '/image/dog.png'),))
 
-# with gzip.open('params_pass_50.tar.gz', 'r') as f:
+# with open('params_pass_50.tar', 'r') as f:
 #    parameters = paddle.parameters.Parameters.from_tar(f)
 
 probs = paddle.infer(

--- a/03.image_classification/index.html
+++ b/03.image_classification/index.html
@@ -211,7 +211,6 @@ We must import and initialize PaddlePaddle (enable/disable GPU, set the number o
 
 ```python
 import sys
-import gzip
 import paddle.v2 as paddle
 from vgg import vgg_bn_drop
 from resnet import resnet_cifar10
@@ -480,7 +479,7 @@ def event_handler(event):
             sys.stdout.flush()
     if isinstance(event, paddle.event.EndPass):
         # save parameters
-        with gzip.open('params_pass_%d.tar.gz' % event.pass_id, 'w') as f:
+        with open('params_pass_%d.tar' % event.pass_id, 'w') as f:
             parameters.to_tar(f)
 
         result = trainer.test(
@@ -550,7 +549,7 @@ cur_dir = os.path.dirname(os.path.realpath(__file__))
 test_data.append((load_image(cur_dir + '/image/dog.png'),))
 
 # users can remove the comments and change the model name
-# with gzip.open('params_pass_50.tar.gz', 'r') as f:
+# with open('params_pass_50.tar', 'r') as f:
 #    parameters = paddle.parameters.Parameters.from_tar(f)
 
 probs = paddle.infer(

--- a/03.image_classification/train.py
+++ b/03.image_classification/train.py
@@ -13,7 +13,6 @@
 # limitations under the License
 
 import sys
-import gzip
 
 import paddle.v2 as paddle
 
@@ -67,7 +66,7 @@ def main():
                 sys.stdout.flush()
         if isinstance(event, paddle.event.EndPass):
             # save parameters
-            with gzip.open('params_pass_%d.tar.gz' % event.pass_id, 'w') as f:
+            with open('params_pass_%d.tar' % event.pass_id, 'w') as f:
                 parameters.to_tar(f)
 
             result = trainer.test(
@@ -116,7 +115,7 @@ def main():
     test_data.append((load_image(cur_dir + '/image/dog.png'), ))
 
     # users can remove the comments and change the model name
-    # with gzip.open('params_pass_50.tar.gz', 'r') as f:
+    # with open('params_pass_50.tar', 'r') as f:
     #    parameters = paddle.parameters.Parameters.from_tar(f)
 
     probs = paddle.infer(

--- a/04.word2vec/README.cn.md
+++ b/04.word2vec/README.cn.md
@@ -302,8 +302,6 @@ trainer = paddle.trainer.SGD(cost, parameters, adagrad)
 `paddle.batch`的输入是一个reader，输出是一个batched reader —— 在PaddlePaddle里，一个reader每次yield一条训练数据，而一个batched reader每次yield一个minbatch。
 
 ```python
-import gzip
-
 def event_handler(event):
     if isinstance(event, paddle.event.EndIteration):
         if event.batch_id % 100 == 0:
@@ -315,7 +313,7 @@ def event_handler(event):
                     paddle.batch(
                         paddle.dataset.imikolov.test(word_dict, N), 32))
         print "Pass %d, Testing metrics %s" % (event.pass_id, result.metrics)
-        with gzip.open("model_%d.tar.gz"%event.pass_id, 'w') as f:
+        with open("model_%d.tar"%event.pass_id, 'w') as f:
             parameters.to_tar(f)
 
 trainer.train(

--- a/04.word2vec/README.md
+++ b/04.word2vec/README.md
@@ -313,8 +313,6 @@ Next, we will begin the training process. `paddle.dataset.imikolov.train()` and 
 `paddle.batch` takes reader as input, outputs a **batched reader**: In PaddlePaddle, a reader outputs a single data instance at a time but batched reader outputs a minibatch of data instances.
 
 ```python
-import gzip
-
 def event_handler(event):
     if isinstance(event, paddle.event.EndIteration):
         if event.batch_id % 100 == 0:
@@ -326,7 +324,7 @@ def event_handler(event):
                     paddle.batch(
                         paddle.dataset.imikolov.test(word_dict, N), 32))
         print "Pass %d, Testing metrics %s" % (event.pass_id, result.metrics)
-        with gzip.open("model_%d.tar.gz"%event.pass_id, 'w') as f:
+        with open("model_%d.tar"%event.pass_id, 'w') as f:
             parameters.to_tar(f)
 
 trainer.train(

--- a/04.word2vec/index.cn.html
+++ b/04.word2vec/index.cn.html
@@ -344,8 +344,6 @@ trainer = paddle.trainer.SGD(cost, parameters, adagrad)
 `paddle.batch`的输入是一个reader，输出是一个batched reader —— 在PaddlePaddle里，一个reader每次yield一条训练数据，而一个batched reader每次yield一个minbatch。
 
 ```python
-import gzip
-
 def event_handler(event):
     if isinstance(event, paddle.event.EndIteration):
         if event.batch_id % 100 == 0:
@@ -357,7 +355,7 @@ def event_handler(event):
                     paddle.batch(
                         paddle.dataset.imikolov.test(word_dict, N), 32))
         print "Pass %d, Testing metrics %s" % (event.pass_id, result.metrics)
-        with gzip.open("model_%d.tar.gz"%event.pass_id, 'w') as f:
+        with open("model_%d.tar"%event.pass_id, 'w') as f:
             parameters.to_tar(f)
 
 trainer.train(

--- a/04.word2vec/index.html
+++ b/04.word2vec/index.html
@@ -355,8 +355,6 @@ Next, we will begin the training process. `paddle.dataset.imikolov.train()` and 
 `paddle.batch` takes reader as input, outputs a **batched reader**: In PaddlePaddle, a reader outputs a single data instance at a time but batched reader outputs a minibatch of data instances.
 
 ```python
-import gzip
-
 def event_handler(event):
     if isinstance(event, paddle.event.EndIteration):
         if event.batch_id % 100 == 0:
@@ -368,7 +366,7 @@ def event_handler(event):
                     paddle.batch(
                         paddle.dataset.imikolov.test(word_dict, N), 32))
         print "Pass %d, Testing metrics %s" % (event.pass_id, result.metrics)
-        with gzip.open("model_%d.tar.gz"%event.pass_id, 'w') as f:
+        with open("model_%d.tar"%event.pass_id, 'w') as f:
             parameters.to_tar(f)
 
 trainer.train(

--- a/07.label_semantic_roles/README.cn.md
+++ b/07.label_semantic_roles/README.cn.md
@@ -189,7 +189,6 @@ conll05st-release/
 ```python
 import math
 import numpy as np
-import gzip
 import paddle.v2 as paddle
 import paddle.v2.dataset.conll05 as conll05
 import paddle.v2.evaluator as evaluator
@@ -448,7 +447,7 @@ def event_handler(event):
 
     if isinstance(event, paddle.event.EndPass):
         # save parameters
-        with gzip.open('params_pass_%d.tar.gz' % event.pass_id, 'w') as f:
+        with open('params_pass_%d.tar' % event.pass_id, 'w') as f:
             parameters.to_tar(f)
 
         result = trainer.test(reader=reader, feeding=feeding)

--- a/07.label_semantic_roles/README.md
+++ b/07.label_semantic_roles/README.md
@@ -211,7 +211,6 @@ Here we fetch the dictionary, and print its size:
 ```python
 import math
 import numpy as np
-import gzip
 import paddle.v2 as paddle
 import paddle.v2.dataset.conll05 as conll05
 import paddle.v2.evaluator as evaluator
@@ -466,7 +465,7 @@ def event_handler(event):
 
     if isinstance(event, paddle.event.EndPass):
         # save parameters
-        with gzip.open('params_pass_%d.tar.gz' % event.pass_id, 'w') as f:
+        with open('params_pass_%d.tar' % event.pass_id, 'w') as f:
             parameters.to_tar(f)
 
         result = trainer.test(reader=reader, feeding=feeding)

--- a/07.label_semantic_roles/index.cn.html
+++ b/07.label_semantic_roles/index.cn.html
@@ -231,7 +231,6 @@ conll05st-release/
 ```python
 import math
 import numpy as np
-import gzip
 import paddle.v2 as paddle
 import paddle.v2.dataset.conll05 as conll05
 import paddle.v2.evaluator as evaluator
@@ -490,7 +489,7 @@ def event_handler(event):
 
     if isinstance(event, paddle.event.EndPass):
         # save parameters
-        with gzip.open('params_pass_%d.tar.gz' % event.pass_id, 'w') as f:
+        with open('params_pass_%d.tar' % event.pass_id, 'w') as f:
             parameters.to_tar(f)
 
         result = trainer.test(reader=reader, feeding=feeding)

--- a/07.label_semantic_roles/index.html
+++ b/07.label_semantic_roles/index.html
@@ -253,7 +253,6 @@ Here we fetch the dictionary, and print its size:
 ```python
 import math
 import numpy as np
-import gzip
 import paddle.v2 as paddle
 import paddle.v2.dataset.conll05 as conll05
 import paddle.v2.evaluator as evaluator
@@ -508,7 +507,7 @@ def event_handler(event):
 
     if isinstance(event, paddle.event.EndPass):
         # save parameters
-        with gzip.open('params_pass_%d.tar.gz' % event.pass_id, 'w') as f:
+        with open('params_pass_%d.tar' % event.pass_id, 'w') as f:
             parameters.to_tar(f)
 
         result = trainer.test(reader=reader, feeding=feeding)

--- a/07.label_semantic_roles/train.py
+++ b/07.label_semantic_roles/train.py
@@ -1,6 +1,5 @@
 import math
 import numpy as np
-import gzip
 import paddle.v2 as paddle
 import paddle.v2.dataset.conll05 as conll05
 import paddle.v2.evaluator as evaluator
@@ -183,7 +182,7 @@ def main():
 
         if isinstance(event, paddle.event.EndPass):
             # save parameters
-            with gzip.open('params_pass_%d.tar.gz' % event.pass_id, 'w') as f:
+            with open('params_pass_%d.tar' % event.pass_id, 'w') as f:
                 parameters.to_tar(f)
 
             result = trainer.test(reader=reader, feeding=feeding)

--- a/08.machine_translation/train.py
+++ b/08.machine_translation/train.py
@@ -1,12 +1,11 @@
 import sys
-import gzip
 import numpy as np
 
 import paddle.v2 as paddle
 
 
 def save_model(parameters, save_path):
-    with gzip.open(save_path, 'w') as f:
+    with open(save_path, 'w') as f:
         parameters.to_tar(f)
 
 
@@ -173,13 +172,13 @@ def main():
                     sys.stdout.flush()
 
                 if not event.batch_id % 10:
-                    save_path = 'params_pass_%05d_batch_%05d.tar.gz' % (
+                    save_path = 'params_pass_%05d_batch_%05d.tar' % (
                         event.pass_id, event.batch_id)
                     save_model(parameters, save_path)
 
             if isinstance(event, paddle.event.EndPass):
                 # save parameters
-                save_path = 'params_pass_%05d.tar.gz' % (event.pass_id)
+                save_path = 'params_pass_%05d.tar' % (event.pass_id)
                 save_model(parameters, save_path)
 
         # start to train


### PR DESCRIPTION
Compressing the model dramatically slows down model read and write
with a little benefit: model compression ratio is very low.