### PR TITLE
fix recognize_digits infer

### DIFF
--- a/02.recognize_digits/README.cn.md
+++ b/02.recognize_digits/README.cn.md
@@ -321,7 +321,7 @@ def load_image(file):
     im = Image.open(file).convert('L')
     im = im.resize((28, 28), Image.ANTIALIAS)
     im = np.array(im).astype(np.float32).flatten()
-    im = im / 255.0
+    im = im / 255.0 * 2.0 - 1.0
     return im
 
 test_data = []

--- a/02.recognize_digits/README.md
+++ b/02.recognize_digits/README.md
@@ -325,7 +325,7 @@ def load_image(file):
     im = Image.open(file).convert('L')
     im = im.resize((28, 28), Image.ANTIALIAS)
     im = np.array(im).astype(np.float32).flatten()
-    im = im / 255.0
+    im = im / 255.0 * 2.0 - 1.0
     return im
 
 test_data = []

--- a/02.recognize_digits/index.cn.html
+++ b/02.recognize_digits/index.cn.html
@@ -363,7 +363,7 @@ def load_image(file):
     im = Image.open(file).convert('L')
     im = im.resize((28, 28), Image.ANTIALIAS)
     im = np.array(im).astype(np.float32).flatten()
-    im = im / 255.0
+    im = im / 255.0 * 2.0 - 1.0
     return im
 
 test_data = []

--- a/02.recognize_digits/index.html
+++ b/02.recognize_digits/index.html
@@ -367,7 +367,7 @@ def load_image(file):
     im = Image.open(file).convert('L')
     im = im.resize((28, 28), Image.ANTIALIAS)
     im = np.array(im).astype(np.float32).flatten()
-    im = im / 255.0
+    im = im / 255.0 * 2.0 - 1.0
     return im
 
 test_data = []

--- a/02.recognize_digits/train.py
+++ b/02.recognize_digits/train.py
@@ -112,7 +112,7 @@ def main():
         im = Image.open(file).convert('L')
         im = im.resize((28, 28), Image.ANTIALIAS)
         im = np.array(im).astype(np.float32).flatten()
-        im = im / 255.0
+        im = im / 255.0 * 2.0 - 1.0
         return im
 
     test_data = []


### PR DESCRIPTION
infer过程中对图片的处理与训练的时候不一致
在paddle/v2/dataset/mnist.py中66行定义的images = images / 255.0 * 2.0 - 1.0