### PR TITLE
Doc: update training with GPU parameters setting in maindir's README

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -51,12 +51,12 @@ nvidia-docker run -d -p 8888:8888 docker.paddlepaddlehub.com/book:latest-gpu
 
 还需要将以下代码
 ```python
-paddle.init(use_gpu=False, trainer_count=1)
+use_cuda = False
 ```
 
 改成：
 ```python
-paddle.init(use_gpu=True, trainer_count=1)
+use_cuda = True
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ nvidia-docker run -d -p 8888:8888 docker.paddlepaddlehub.com/book:latest-gpu
 
 Change the code in the chapter that you are reading from
 ```python
-paddle.init(use_gpu=False, trainer_count=1)
+use_cuda = False
 ```
 
 to:
 ```python
-paddle.init(use_gpu=True, trainer_count=1)
+use_cuda = True
 ```
 
 


### PR DESCRIPTION
`paddle.init()` is no longer in use in fluid.

related issue: https://github.com/PaddlePaddle/book/issues/589