### PR TITLE
Update the order of step and epoch_id in the print function (train.py…

### DIFF
--- a/02.recognize_digits/train.py
+++ b/02.recognize_digits/train.py
@@ -125,7 +125,7 @@ def train(nn_type,
                 feed=feeder.feed(data),
                 fetch_list=[avg_loss, acc])
             if step % 100 == 0:
-                print("Pass %d, Batch %d, Cost %f" % (step, epoch_id,
+                print("Pass %d, Batch %d, Cost %f" % (epoch_id, step,
                                                       metrics[0]))
             step += 1
         # test for epoch


### PR DESCRIPTION
train.py中第128行打印的step和epoch_id顺序似乎反了，一个batch应该是一个step，一个pass应该是一个epoch。
fix the issue#709