### PR TITLE
test=develop,Modify the location of test_program definition

### DIFF
--- a/01.fit_a_line/README.cn.md
+++ b/01.fit_a_line/README.cn.md
@@ -213,13 +213,14 @@ avg_loss = fluid.layers.mean(cost) # 对方差求均值，得到平均损失
 在下面的 `SGD optimizer`，`learning_rate` 是学习率，与网络的训练收敛速度有关系。
 
 ```python
-sgd_optimizer = fluid.optimizer.SGD(learning_rate=0.001)
-sgd_optimizer.minimize(avg_loss)
-
 #克隆main_program得到test_program
 #有些operator在训练和测试之间的操作是不同的，例如batch_norm，使用参数for_test来区分该程序是用来训练还是用来测试
 #该api不会删除任何操作符,请在backward和optimization之前使用
 test_program = main_program.clone(for_test=True)
+
+sgd_optimizer = fluid.optimizer.SGD(learning_rate=0.001)
+sgd_optimizer.minimize(avg_loss)
+
 ```
 
 ### 定义运算场所

--- a/01.fit_a_line/README.md
+++ b/01.fit_a_line/README.md
@@ -215,13 +215,14 @@ For details, please refer to:
 `SGD optimizer`, `learning_rate` below are learning rate, which is related to rate of convergence for train of network.
 
 ```python
-sgd_optimizer = fluid.optimizer.SGD(learning_rate=0.001)
-sgd_optimizer.minimize(avg_loss)
-
 #Clone main_program to get test_program
 # operations of some operators are different between train and test. For example, batch_norm use parameter for_test to determine whether the program is for training or for testing.
 #The api will not delete any operator, please apply it before backward and optimization.
 test_program = main_program.clone(for_test=True)
+
+sgd_optimizer = fluid.optimizer.SGD(learning_rate=0.001)
+sgd_optimizer.minimize(avg_loss)
+
 ```
 
 ### Define Training Place

--- a/01.fit_a_line/index.cn.html
+++ b/01.fit_a_line/index.cn.html
@@ -255,13 +255,14 @@ avg_loss = fluid.layers.mean(cost) # 对方差求均值，得到平均损失
 在下面的 `SGD optimizer`，`learning_rate` 是学习率，与网络的训练收敛速度有关系。
 
 ```python
-sgd_optimizer = fluid.optimizer.SGD(learning_rate=0.001)
-sgd_optimizer.minimize(avg_loss)
-
 #克隆main_program得到test_program
 #有些operator在训练和测试之间的操作是不同的，例如batch_norm，使用参数for_test来区分该程序是用来训练还是用来测试
 #该api不会删除任何操作符,请在backward和optimization之前使用
 test_program = main_program.clone(for_test=True)
+
+sgd_optimizer = fluid.optimizer.SGD(learning_rate=0.001)
+sgd_optimizer.minimize(avg_loss)
+
 ```
 
 ### 定义运算场所

--- a/01.fit_a_line/index.html
+++ b/01.fit_a_line/index.html
@@ -257,13 +257,14 @@ For details, please refer to:
 `SGD optimizer`, `learning_rate` below are learning rate, which is related to rate of convergence for train of network.
 
 ```python
-sgd_optimizer = fluid.optimizer.SGD(learning_rate=0.001)
-sgd_optimizer.minimize(avg_loss)
-
 #Clone main_program to get test_program
 # operations of some operators are different between train and test. For example, batch_norm use parameter for_test to determine whether the program is for training or for testing.
 #The api will not delete any operator, please apply it before backward and optimization.
 test_program = main_program.clone(for_test=True)
+
+sgd_optimizer = fluid.optimizer.SGD(learning_rate=0.001)
+sgd_optimizer.minimize(avg_loss)
+
 ```
 
 ### Define Training Place

--- a/01.fit_a_line/train.py
+++ b/01.fit_a_line/train.py
@@ -101,10 +101,10 @@ def main():
     cost = fluid.layers.square_error_cost(input=y_predict, label=y)
     avg_loss = fluid.layers.mean(cost)
 
+    test_program = main_program.clone(for_test=True)
+
     sgd_optimizer = fluid.optimizer.SGD(learning_rate=0.001)
     sgd_optimizer.minimize(avg_loss)
-
-    test_program = main_program.clone(for_test=True)
 
     # can use CPU or GPU
     use_cuda = args.use_gpu


### PR DESCRIPTION
修改了线性规划案例(01.fit_a_line)train.py文件，对应的md文件和html文件中test_program 定义位置不正确的问题，将原本定义在优化器后面的test_program 移到之前，这样，当使用测试数据运行 test_program时,就可以做到运行测试程序，而不影响训练结果。
