### PR TITLE
remove the usage of InferenceTranspiler

### DIFF
--- a/03.image_classification/README.cn.md
+++ b/03.image_classification/README.cn.md
@@ -538,26 +538,11 @@ with fluid.scope_guard(inference_scope):
     [inference_program, feed_target_names,
      fetch_targets] = fluid.io.load_inference_model(params_dirname, exe)
 
-        # The input's dimension of conv should be 4-D or 5-D.
-        # Use inference_transpiler to speedup
-    inference_transpiler_program = inference_program.clone()
-    t = fluid.transpiler.InferenceTranspiler()
-    t.transpile(inference_transpiler_program, place)
-
         # Construct feed as a dictionary of {feed_target_name: feed_target_data}
         # and results will contain a list of data corresponding to fetch_targets.
     results = exe.run(inference_program,
                       feed={feed_target_names[0]: img},
                       fetch_list=fetch_targets)
-
-    transpiler_results = exe.run(inference_transpiler_program,
-                                 feed={feed_target_names[0]: img},
-                                 fetch_list=fetch_targets)
-
-    assert len(results[0]) == len(transpiler_results[0])
-    for i in range(len(results[0])):
-        numpy.testing.assert_almost_equal(
-            results[0][i], transpiler_results[0][i], decimal=5)
 
     # infer label
     label_list = [

--- a/03.image_classification/README.md
+++ b/03.image_classification/README.md
@@ -541,26 +541,11 @@ with fluid.scope_guard(inference_scope):
     [inference_program, feed_target_names,
      fetch_targets] = fluid.io.load_inference_model(params_dirname, exe)
 
-        # The input's dimension of conv should be 4-D or 5-D.
-        # Use inference_transpiler to speedup
-    inference_transpiler_program = inference_program.clone()
-    t = fluid.transpiler.InferenceTranspiler()
-    t.transpile(inference_transpiler_program, place)
-
         # Construct feed as a dictionary of {feed_target_name: feed_target_data}
         # and results will contain a list of data corresponding to fetch_targets.
     results = exe.run(inference_program,
                       feed={feed_target_names[0]: img},
                       fetch_list=fetch_targets)
-
-    transpiler_results = exe.run(inference_transpiler_program,
-                                 feed={feed_target_names[0]: img},
-                                 fetch_list=fetch_targets)
-
-    assert len(results[0]) == len(transpiler_results[0])
-    for i in range(len(results[0])):
-        numpy.testing.assert_almost_equal(
-            results[0][i], transpiler_results[0][i], decimal=5)
 
     # infer label
     label_list = [

--- a/03.image_classification/index.cn.html
+++ b/03.image_classification/index.cn.html
@@ -580,26 +580,11 @@ with fluid.scope_guard(inference_scope):
     [inference_program, feed_target_names,
      fetch_targets] = fluid.io.load_inference_model(params_dirname, exe)
 
-        # The input's dimension of conv should be 4-D or 5-D.
-        # Use inference_transpiler to speedup
-    inference_transpiler_program = inference_program.clone()
-    t = fluid.transpiler.InferenceTranspiler()
-    t.transpile(inference_transpiler_program, place)
-
         # Construct feed as a dictionary of {feed_target_name: feed_target_data}
         # and results will contain a list of data corresponding to fetch_targets.
     results = exe.run(inference_program,
                       feed={feed_target_names[0]: img},
                       fetch_list=fetch_targets)
-
-    transpiler_results = exe.run(inference_transpiler_program,
-                                 feed={feed_target_names[0]: img},
-                                 fetch_list=fetch_targets)
-
-    assert len(results[0]) == len(transpiler_results[0])
-    for i in range(len(results[0])):
-        numpy.testing.assert_almost_equal(
-            results[0][i], transpiler_results[0][i], decimal=5)
 
     # infer label
     label_list = [

--- a/03.image_classification/index.html
+++ b/03.image_classification/index.html
@@ -581,28 +581,13 @@ inference_scope = fluid.core.Scope()
 with fluid.scope_guard(inference_scope):
 
     [inference_program, feed_target_names,
-     fetch_targets] = fluid.io.load_inference_model(params_dirname, exe)
-
-        # The input's dimension of conv should be 4-D or 5-D.
-        # Use inference_transpiler to speedup
-    inference_transpiler_program = inference_program.clone()
-    t = fluid.transpiler.InferenceTranspiler()
-    t.transpile(inference_transpiler_program, place)
+     fetch_targets] = fluid.io.load_inference_model(params_dirname, exe)   
 
         # Construct feed as a dictionary of {feed_target_name: feed_target_data}
         # and results will contain a list of data corresponding to fetch_targets.
     results = exe.run(inference_program,
                       feed={feed_target_names[0]: img},
                       fetch_list=fetch_targets)
-
-    transpiler_results = exe.run(inference_transpiler_program,
-                                 feed={feed_target_names[0]: img},
-                                 fetch_list=fetch_targets)
-
-    assert len(results[0]) == len(transpiler_results[0])
-    for i in range(len(results[0])):
-        numpy.testing.assert_almost_equal(
-            results[0][i], transpiler_results[0][i], decimal=5)
 
     # infer label
     label_list = [

--- a/03.image_classification/train.py
+++ b/03.image_classification/train.py
@@ -191,28 +191,12 @@ def infer(use_cuda, params_dirname=None):
         [inference_program, feed_target_names,
          fetch_targets] = fluid.io.load_inference_model(params_dirname, exe)
 
-        # The input's dimension of conv should be 4-D or 5-D.
-        # Use inference_transpiler to speedup
-        inference_transpiler_program = inference_program.clone()
-        t = fluid.transpiler.InferenceTranspiler()
-        t.transpile(inference_transpiler_program, place)
-
         # Construct feed as a dictionary of {feed_target_name: feed_target_data}
         # and results will contain a list of data corresponding to fetch_targets.
         results = exe.run(
             inference_program,
             feed={feed_target_names[0]: img},
             fetch_list=fetch_targets)
-
-        transpiler_results = exe.run(
-            inference_transpiler_program,
-            feed={feed_target_names[0]: img},
-            fetch_list=fetch_targets)
-
-        assert len(results[0]) == len(transpiler_results[0])
-        for i in range(len(results[0])):
-            numpy.testing.assert_almost_equal(
-                results[0][i], transpiler_results[0][i], decimal=5)
 
         # infer label
         label_list = [


### PR DESCRIPTION
remove the usage of InferenceTranspiler in  03.image_classification train.py，README.cn.md， README.md, index.html and index.cn.html