### PR TITLE
fix CI error caused by the newest identify not supprot python2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
       - golang
   ssh_known_hosts: 13.229.163.131
 before_install:
-  -  sudo pip install -U virtualenv pre-commit pip
+  -  sudo pip install -U virtualenv pre-commit pip identify==1.5.9
   -  GOPATH=/tmp/go go get -u github.com/wangkuiyi/ipynb/markdown-to-ipynb
 script:
   -  PATH=/tmp/go/bin:$PATH .travis/precommit.sh


### PR DESCRIPTION
修复CI中`pre-commit`运行错误。

使用较高版本identify==1.6.1库，其中使用了python3语法，在python2中不支持，限制使用identify==1.5.9版本来解决该问题。